### PR TITLE
Patch numpy.array_equal if numpy version > 1.8

### DIFF
--- a/facadedevice/graph.py
+++ b/facadedevice/graph.py
@@ -1,5 +1,3 @@
-"""Provide objects for building reactive graphs."""
-
 # Imports
 
 import time
@@ -7,8 +5,32 @@ import warnings
 from functools import partial
 from collections import Mapping, namedtuple, defaultdict
 
-from numpy import array_equal
+
 from tango import AttrQuality
+
+
+def patched_array_equal(a1, a2):
+    from numpy import asarray
+    try:
+        a1, a2 = asarray(a1), asarray(a2)
+    except Exception:
+        return False
+    if a1.shape != a2.shape:
+        return False
+    return bool(asarray(a1 == a2).all())
+
+
+def check_numpy_version():
+    from numpy.version import version as numpy_version
+    import distutils.version
+    if distutils.version.StrictVersion(numpy_version) < "1.8":
+        return patched_array_equal
+    else:
+        from numpy import array_equal
+        return array_equal
+
+
+array_equal = check_numpy_version()
 
 # Constants
 

--- a/facadedevice/graph.py
+++ b/facadedevice/graph.py
@@ -1,3 +1,5 @@
+"""Provide objects for building reactive graphs."""
+
 # Imports
 
 import time

--- a/facadedevice/graph.py
+++ b/facadedevice/graph.py
@@ -7,6 +7,7 @@ from collections import Mapping, namedtuple, defaultdict
 
 
 from tango import AttrQuality
+from numpy.version import version as numpy_version
 
 
 def patched_array_equal(a1, a2):
@@ -21,7 +22,6 @@ def patched_array_equal(a1, a2):
 
 
 def check_numpy_version():
-    from numpy.version import version as numpy_version
     import distutils.version
     if distutils.version.StrictVersion(numpy_version) < "1.8":
         return patched_array_equal

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,9 @@ setup(
 
     # Requirements
     install_requires=['pytango>=9.2.1'],
-    tests_require=['pytest-mock', 'pytest-xdist', 'pytest-coverage'],
+    tests_require=['pytest-mock',
+                   'pytest-xdist',
+                   'pytest-coverage',
+                   'numpy>=1.0.8'],
     setup_requires=['pytest-runner'] if TESTING else [],
 )

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'Topic :: Software Development :: Libraries'],
 
     # Requirements
-    install_requires=['pytango>=9.2.1, numpy'],
+    install_requires=['pytango>=9.2.1', 'numpy'],
     tests_require=['pytest-mock',
                    'pytest-xdist',
                    'pytest-coverage',

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     tests_require=['pytest-mock',
                    'pytest-xdist',
                    'pytest-coverage',
-                   'numpy>=1.0.8'],
+                   'numpy>=1.8.0'],
     setup_requires=['pytest-runner'] if TESTING else [],
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_readme(name='README.rst'):
 # Setup
 setup(
     name='facadedevice',
-    version='1.0.2',
+    version='1.0.2.dev0',
     packages=['facadedevice'],
 
     # Metadata
@@ -44,7 +44,7 @@ setup(
         'Topic :: Software Development :: Libraries'],
 
     # Requirements
-    install_requires=['pytango>=9.2.1'],
+    install_requires=['pytango>=9.2.1, numpy'],
     tests_require=['pytest-mock',
                    'pytest-xdist',
                    'pytest-coverage',

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -25,6 +25,8 @@ def test_compare_triplet():
     assert a != 1 != b
     assert a != 'test' != b
     assert a != 'tes' != b
+    h = triplet(['test'], 0.0, VALID)
+    assert h == h
 
 
 def test_triplet_constructor():

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,13 +2,36 @@
 # Imports
 import numpy
 import pytest
+from mock import MagicMock
 
 # Facade imports
 from facadedevice.graph import Node, RestrictedNode, Graph, triplet
 from facadedevice.graph import VALID, INVALID
+from facadedevice.graph import patched_array_equal
 
 
-def test_compare_triplet():
+def test_patched_array_equal():
+    assert patched_array_equal([1], [1])
+    assert not patched_array_equal([1], [2])
+    assert not patched_array_equal([1, 2], [1])
+    asarray_mock = MagicMock()
+    asarray_mock.shape
+    asarray_mock.side_effect = Exception()
+    numpy.asarray = asarray_mock
+    assert not patched_array_equal([123], [123])
+
+
+@pytest.fixture(params=[numpy.version.version, "1.7.1", "1.8.0"])
+def numpy_version(request):
+    return request.param
+
+
+def test_compare_triplet(numpy_version):
+    # Mock numpy version
+    from facadedevice import graph
+    graph.numpy_version = numpy_version
+    # Reload array_equal
+    graph.array_equal = graph.check_numpy_version()
     a = triplet([1, 2], 0.0)
     b = triplet(numpy.array([1, 2]), 0.0)
     assert a == b == a == ([1, 2], 0.0, VALID) == b

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,7 +2,6 @@
 # Imports
 import numpy
 import pytest
-from mock import MagicMock
 
 # Facade imports
 from facadedevice.graph import Node, RestrictedNode, Graph, triplet
@@ -10,11 +9,11 @@ from facadedevice.graph import VALID, INVALID
 from facadedevice.graph import patched_array_equal
 
 
-def test_patched_array_equal():
+def test_patched_array_equal(mocker):
     assert patched_array_equal([1], [1])
     assert not patched_array_equal([1], [2])
     assert not patched_array_equal([1, 2], [1])
-    asarray_mock = MagicMock()
+    asarray_mock = mocker.Mock()
     asarray_mock.shape
     asarray_mock.side_effect = Exception()
     numpy.asarray = asarray_mock


### PR DESCRIPTION
See issue #3 

As centos7 default numpy version is 1.7.1, it is maybe better to patch array_equal instead of forcing numpy version.

Tested in a Conda environment with numpy 1.7.1.
