### PR TITLE
Exclude property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 
 install:
   # Install build dependencies
-  - conda install --yes -c tango-controls pytango=9.2.1
+  - conda install --yes -c esrf-bcu pytango=9.2.2
   - conda install --yes numpy  # Not a strong requirement yet
   # Install coveralls
   - pip install coveralls

--- a/facadedevice/utils.py
+++ b/facadedevice/utils.py
@@ -78,10 +78,12 @@ def check_attribute(name, writable=False):
 
 # Attribute from wildcard
 
-def attributes_from_wildcard(wildcard):
+def attributes_from_wildcard(wildcard, exclude=[]):
     db = Database()
     wdev, wattr = split_tango_name(wildcard)
-    for device in db.get_device_exported(wdev):
+    devices = [d for d in db.get_device_exported(wdev)
+               if d.lower() not in exclude]
+    for device in devices:
         proxy = create_device_proxy(device)
         infos = proxy.attribute_list_query()
         attrs = sorted(info.name.lower() for info in infos)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_readme(name='README.rst'):
 # Setup
 setup(
     name='facadedevice',
-    version='1.0.2.dev1',
+    version='1.0.2.dev2',
     packages=['facadedevice'],
 
     # Metadata


### PR DESCRIPTION
Add exclude_property field to the combined_attribute definition.

It allows to define a tango property to explicitly list device to exclude from the wildcard property ouput.

```python
@combined_attribute(                                                     
    dtype=float,                                                         
    property_name='prop',                                                
    exclude_property='exclude')                                          
def attr(self, *values):                                                 
    return sum(values)
```